### PR TITLE
Documenting usage of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ yarn
 
 Since each package has its own `package.json`, you can manage it just like you would any other NPM package.
 
-To add a new package.
+To add a new package:
 
 ``` bash
 $ mkdir packages/new-package
@@ -131,6 +131,14 @@ $ yarn init
 ```
 
 Packages can also be optionally published to NPM.
+
+To use a package:
+
+```bash
+$ yarn add new-package@1.0.0
+```
+
+Note that packages should be added by specifying the version number declared in their `package.json`. Otherwise, yarn tries to find the dependency in the registry.
 
 ### Libs
 


### PR DESCRIPTION
PR to save time and simplify the repo's existing tooling for future developers and beginners like me.

It was unclear how to use packages under `packages/*` in your own `services` and `lib` for developers unfamiliar with yarn workspaces.

Changes inspired by [this blog](https://doppelmutzi.github.io/monorepo-lerna-yarn-workspaces/#yarn-workspaces),

> With the following command, I add one of my own packages ("awesome-components") to another package ("awesome-app") as dependency.
>
> I found out that adding local packages should be done <ins>by specifying a version number, otherwise yarn tries to find the dependency in the registry.</ins>
>
> `$ yarn workspace @doppelmutzi/awesome-app add @doppelmutzi/awesome-components@0.1.0 -D`